### PR TITLE
chore: add weekly branch cleanup workflow

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,27 @@
+name: Branch Cleanup
+
+# Managed by aviva-verde/github-branch-cleanup rollout.
+# Edit `with:` values below to tune behaviour for this repo.
+# Once you've reviewed a dry run and are happy, flip `dry_run` to `false`.
+
+on:
+  schedule:
+    # Every Saturday at 00:00 UTC
+    - cron: "0 0 * * 6"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview mode without actual deletions"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  cleanup:
+    uses: aviva-verde/github-branch-cleanup/.github/workflows/reusable-branch-cleanup.yml@main
+    permissions:
+      contents: write
+    with:
+      stale_days: 270
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || true }}
+      exclude_patterns: "main,master,develop,staging,production,release/*,hotfix/*,support/*"


### PR DESCRIPTION
Adds a scheduled workflow that runs every Saturday at 00:00 UTC and cleans up branches older than 270 days (~9 months).

The workflow delegates to the org-wide reusable workflow in [`aviva-verde/github-branch-cleanup`](https://github.com/aviva-verde/github-branch-cleanup), so future config changes are centralised.

**Starts in `dry_run: true`** — review one run, then flip the flag to `false` in `.github/workflows/branch-cleanup.yml` to enable live deletions.

Protected branches and `main,master,develop,staging,production,release/*,hotfix/*,support/*` are excluded by default.

_Rolled out by `scripts/rollout.sh`._